### PR TITLE
Fix SoundTree failing to record from my SCO-enabled devices

### DIFF
--- a/app/src/main/java/app/soundtree/service/RecordingService.kt
+++ b/app/src/main/java/app/soundtree/service/RecordingService.kt
@@ -395,7 +395,11 @@ class RecordingService : Service() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             // API 31+: setCommunicationDevice replaces startBluetoothSco.
             // Returns false if the device isn't available; fall back immediately.
-            val accepted = preferredInputDevice?.let { audioManager.setCommunicationDevice(it) } ?: false
+            var accepted : Boolean = preferredInputDevice?.let { audioManager.setCommunicationDevice(it) } ?: false
+            if (!accepted) {
+                accepted = audioManager.availableCommunicationDevices.find { it.address == preferredInputDevice?.address }
+                    ?.let { audioManager.setCommunicationDevice(it) } ?: false
+            }
             if (!accepted) {
                 mainHandler.removeCallbacks(scoTimeoutRunnable)
                 unregisterScoReceiver()


### PR DESCRIPTION
Thank you for the app! It seems like this is the only open source app that supports recording from SCO devices. I didn't realize it initially because when I selected either of the SCO-enabled devices that I own as a recording source, SoundTree did not use them and instead fell back to the default microphone. This fixes that.

I happened to spend enough time to make this into a proper PR so that others can enjoy it too :)

Alternative approaches that could be taken to solve the problem:

1. Use audioManager.availableCommunicationDevices instead of audioManager.getDevices in showInputSourceDialog. This shows the same list of recording sources on my device, but I'm not sure if it would do that in all cases.
2. Make this change the default method instead of just a fallback. Maybe `var accepted : Boolean = preferredInputDevice?.let { audioManager.setCommunicationDevice(it) } ?: false` never succeeds? Not sure.

Hopefully my PR and commit message are clear enough about what's going on. If not, feel free to ask questions!