### PR TITLE
Fix InvalidForegroundServiceTypeException crash on Android 14+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <!-- Required for AudioManager.startBluetoothSco() -->
@@ -62,6 +63,16 @@
             android:exported="false"
             android:windowSoftInputMode="adjustResize"
             android:screenOrientation="portrait" />
+
+        <!--
+            WorkManager's SystemForegroundService needs a foregroundServiceType
+            on API 34+ or startForeground() throws InvalidForegroundServiceTypeException.
+            The BackupWorker uses dataSync for its backup file copy operations.
+        -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
 
         <!-- Recording foreground service (microphone) -->
         <service

--- a/app/src/main/java/app/soundtree/worker/BackupWorker.kt
+++ b/app/src/main/java/app/soundtree/worker/BackupWorker.kt
@@ -5,6 +5,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.net.Uri
 import androidx.core.app.NotificationCompat
 import androidx.documentfile.provider.DocumentFile
@@ -1268,7 +1269,8 @@ class BackupWorker(context: Context, params: WorkerParameters) :
                 text        = "Backup in progress\u2026",
                 ongoing     = true,
                 run         = null,
-            )
+            ),
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
         )
     }
 }


### PR DESCRIPTION
## Summary

Fixes #12 — SoundTree crashes with `InvalidForegroundServiceTypeException` when the BackupWorker calls `setForeground()` on Android 14+ (API 34+).

The crash occurs because:
1. WorkManager's `SystemForegroundService` has no `foregroundServiceType` declared in the manifest
2. `BackupWorker.getForegroundInfo()` constructs `ForegroundInfo` without specifying a service type

Android 14+ requires all foreground services to declare a type. Without one, `startForeground()` throws and the app crashes. This affects both manual and scheduled backups.

## Changes

- **`AndroidManifest.xml`**: Added `FOREGROUND_SERVICE_DATA_SYNC` permission and merged `foregroundServiceType="dataSync"` onto `androidx.work.impl.foreground.SystemForegroundService` via `tools:node="merge"`
- **`BackupWorker.kt`**: Pass `ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC` to the `ForegroundInfo` constructor in `getForegroundInfo()`

`dataSync` is the appropriate type since the backup worker copies recording files, database snapshots, and metadata to a backup destination.

## Testing

Tested on Pixel 10 Pro XL (GrapheneOS, Android 17, SDK 37):
- Manual backup: no crash, `WM-WorkerWrapper: Worker result SUCCESS`
- Scheduled backup (daily interval): no crash, worker returns SUCCESS
- App remains alive after backup completion (previously crashed and restarted)
- Backup files correctly written to `/sdcard/Recordings/` (db snapshots, recordings, manifest)

Before the fix, every backup attempt produced:
```
E AndroidRuntime: FATAL EXCEPTION: main
E AndroidRuntime: android.app.InvalidForegroundServiceTypeException: Starting FGS with type none callerApp=app.soundtree targetSDK=37 has been prohibited
```

After the fix, logcat is clean with no FATAL exceptions.

## Reference

[Foreground service types are required | Android Developers](https://developer.android.com/about/versions/14/changes/fgs-types-required)